### PR TITLE
ZeroMQ's headers are noticed about static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set( LIBZMQPP_SOURCES
 # Staticlib
 if (ZMQPP_BUILD_STATIC)
   add_library( zmqpp-static STATIC ${LIBZMQPP_SOURCES})
+  target_compile_definitions(zmqpp-static PUBLIC -DZMQ_STATIC)
   target_link_libraries(zmqpp-static ZeroMQ::libzmq-static)
   list( APPEND INSTALL_TARGET_LIST zmqpp-static)
   set( LIB_TO_LINK_TO_EXAMPLES zmqpp-static )


### PR DESCRIPTION
On Windows ZMQPP used static linked ZeroMQ libraries but it doesn't set ZMQ_STATIC definition, consequently __declspec() magic is badly set in ZeroMQ headers.

See: https://github.com/hunter-packages/zeromq4-1/blob/master/include/zmq.h#L55-L71 
and
https://github.com/hunter-packages/zeromq4-1/blob/master/CMakeLists.txt#L603-L608
