### PR TITLE
Hunterized version 4.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ cmake_minimum_required(VERSION 3.0)
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-  URL "https://github.com/ruslo/hunter/archive/v0.14.0.tar.gz"
-  SHA1 "f10609f4be3c5840de53545c1b0d8cfa642fb744"
+  URL "https://github.com/ruslo/hunter/archive/v0.23.142.tar.gz"
+  SHA1 "1d841ca74150c92054896a7f6d88a123dd9e615d"
 )
 
 project(ZMQPP VERSION 4.2.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,6 @@ HunterGate(
 project(ZMQPP VERSION 4.2.0)
 enable_testing()
 
-# prepare C++11
-#set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
-
 # show all warnings
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,19 @@
 #
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0)
+
+include("cmake/HunterGate.cmake")
+HunterGate(
+  URL "https://github.com/ruslo/hunter/archive/v0.14.0.tar.gz"
+  SHA1 "f10609f4be3c5840de53545c1b0d8cfa642fb744"
+)
+
+project(ZMQPP VERSION 4.2.0)
 enable_testing()
 
 # prepare C++11
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+#set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 
 # show all warnings
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
@@ -25,6 +33,8 @@ if(NOT MSVC)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
 endif()
 
+hunter_add_package(ZeroMQ)
+find_package(ZeroMQ CONFIG REQUIRED)
 
 # Set a consistent MACOSX_RPATH default across all CMake versions.  When CMake
 # 2.8.12 is required, change this default to 1.  When CMake 3.0.0 is required,
@@ -35,16 +45,12 @@ if(NOT DEFINED CMAKE_MACOSX_RPATH)
   set(CMAKE_MACOSX_RPATH 0)
 endif()
 
-# If libzmq is build in the same cmake global project and we want to
-# depends on it instead of searching for libzmq in the system, we set this to true
-set( ZMQPP_LIBZMQ_CMAKE   false   CACHE BOOL "libzmq is build through cmake too" )
-
-
 set( ZMQPP_BUILD_STATIC   true   CACHE BOOL "Build the ZMQPP static library" )
 set( ZMQPP_BUILD_SHARED   true   CACHE BOOL "Build the ZMQPP dynamic library" )
 
 set( ZMQPP_BUILD_EXAMPLES false   CACHE BOOL "Build the ZMQPP examples" )
 set( ZMQPP_BUILD_CLIENT   false   CACHE BOOL "Build the ZMQPP client" )
+# never switch on it won't be installed.
 set( ZMQPP_BUILD_TESTS    false   CACHE BOOL "Build the ZMQPP tests" )
 
 
@@ -61,10 +67,6 @@ set( ZEROMQ_INCLUDE_DIR   ""      CACHE PATH "The include directory for ZMQ" )
 
 # Build flags
 set( IS_TRAVIS_CI_BUILD   true    CACHE bool "Defines TRAVIS_CI_BUILD - Should the tests avoid running cases where memory is scarce." )
-
-# Find zmq.h and add its dir to the includes
-find_path(ZEROMQ_INCLUDE zmq.h PATHS ${ZEROMQ_INCLUDE_DIR})
-include_directories(${ZEROMQ_INCLUDE_DIR} ${ZEROMQ_INCLUDE} ${CMAKE_CURRENT_SOURCE_DIR}/src )
 
 # Do not run some tests when building on travis-ci (this cause oom error and kill the test
 # process)
@@ -107,19 +109,8 @@ set( LIBZMQPP_SOURCES
 # Staticlib
 if (ZMQPP_BUILD_STATIC)
   add_library( zmqpp-static STATIC ${LIBZMQPP_SOURCES})
-  target_compile_definitions(zmqpp-static PUBLIC ZMQ_STATIC ZMQPP_STATIC_DEFINE)
-  if (NOT ZMQPP_LIBZMQ_CMAKE)
-    find_library(ZEROMQ_LIBRARY_STATIC ${ZMQPP_LIBZMQ_NAME_STATIC} PATHS ${ZEROMQ_LIB_DIR})
-    if (NOT ZEROMQ_LIBRARY_STATIC)
-      # If libzmq was not installed through CMake, the static binary is libzmq.a not libzmq-static.a
-      find_library(ZEROMQ_LIBRARY_STATIC libzmq.a PATHS ${ZEROMQ_LIB_DIR})
-    endif()
-    target_link_libraries( zmqpp-static ${ZEROMQ_LIBRARY_STATIC})
-  else()
-    # libzmq-static is the name of the target from
-    # libzmq's CMake
-    target_link_libraries(zmqpp-static libzmq-static)
-  endif()
+  target_compile_definitions(zmqpp-static PUBLIC -DZMQ_STATIC)
+  target_link_libraries(zmqpp-static ZeroMQ::libzmq-static)
   list( APPEND INSTALL_TARGET_LIST zmqpp-static)
   set( LIB_TO_LINK_TO_EXAMPLES zmqpp-static )
 endif() # ZMQPP_BUILD_STATIC
@@ -127,17 +118,19 @@ endif() # ZMQPP_BUILD_STATIC
 # Shared lib
 if (ZMQPP_BUILD_SHARED)
   add_library( zmqpp SHARED ${LIBZMQPP_SOURCES})
-  if (NOT ZMQPP_LIBZMQ_CMAKE)
-    find_library(ZEROMQ_LIBRARY_SHARED ${ZMQPP_LIBZMQ_NAME_SHARED} PATHS ${ZEROMQ_LIB_DIR})
-    target_link_libraries( zmqpp ${ZEROMQ_LIBRARY_SHARED} )
-  else()
-    # libzmq is the name of the target from
-    # libzmq's CMake
-    target_link_libraries(zmqpp libzmq)
-  endif()
+
+  target_link_libraries(zmqpp ZeroMQ::libzmq)
+
   list( APPEND INSTALL_TARGET_LIST zmqpp)
   set( LIB_TO_LINK_TO_EXAMPLES zmqpp )
 endif() # ZMQPP_BUILD_SHARED
+
+if ((ZMQPP_BUILD_CLIENT) OR (ZMQPP_BUILD_EXAMPLES) OR (ZMQPP_BUILD_TESTS))
+  hunter_add_package(Boost COMPONENTS program_options thread system test)
+  find_package(Boost CONFIG REQUIRED program_options thread system unit_test_framework)
+
+  include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
+endif()
 
 # We need to link zmqpp to ws2_32 on windows for the implementation of winsock2.h
 if(WIN32)
@@ -176,14 +169,7 @@ endif()
 # ------
 
 if( ZMQPP_BUILD_CLIENT )
-  # Boost
-  # -----
-  set(Boost_USE_STATIC_LIBS ON)
-  set(Boost_USE_MULTITHREADED ON)
-  set(Boost_USE_STATIC_RUNTIME OFF)
-  find_package(Boost REQUIRED COMPONENTS program_options )
-  include_directories( ${Boost_INCLUDE_DIRS} )
-
+  include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
   add_executable( zmqpp-client
     src/client/main.cpp
     src/client/options.cpp
@@ -196,15 +182,6 @@ endif()
 # -----
 
 if( ZMQPP_BUILD_TESTS )
-  #
-  # Boost
-  # -----
-  set(Boost_USE_STATIC_LIBS OFF) # only find static libs
-  set(Boost_USE_MULTITHREADED ON)
-  set(Boost_USE_STATIC_RUNTIME OFF)
-  find_package(Boost REQUIRED COMPONENTS thread system unit_test_framework)
-  include_directories( ${Boost_INCLUDE_DIRS} )
-
   add_executable( zmqpp-test-runner
     src/tests/test_actor.cpp
     src/tests/test_context.cpp
@@ -222,21 +199,48 @@ if( ZMQPP_BUILD_TESTS )
     src/tests/test_auth.cpp
     src/tests/test_proxy.cpp
     )
-  target_link_libraries( zmqpp-test-runner  ${LIB_TO_LINK_TO_EXAMPLES} ${Boost_LIBRARIES})
+  target_link_libraries( zmqpp-test-runner  ${LIB_TO_LINK_TO_EXAMPLES} Boost::thread Boost::system Boost::unit_test_framework)
   add_test( zmqpp-test zmqpp-test-runner --log-level=test-suite )
 endif()
 
 
 # Install
 # -------
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(config_export_name "${PROJECT_NAME}Config")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(project_config "${CMAKE_CURRENT_BINARY_DIR}/${config_export_name}.cmake")
+set(version_config "${CMAKE_CURRENT_BINARY_DIR}/${config_export_name}Version.cmake")
+set(namespace "${PROJECT_NAME}::")
+
 install(TARGETS ${INSTALL_TARGET_LIST}
+        EXPORT "${targets_export_name}"
+        INCLUDES DESTINATION include
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 
 install(DIRECTORY src/zmqpp DESTINATION include/
         FILES_MATCHING PATTERN "*.hpp")
+include(CMakePackageConfigHelpers)
+configure_package_config_file( # Uses target_exports_name
+    "cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+write_basic_package_version_file(
+  "${version_config}" COMPATIBILITY SameMajorVersion)
+
+install(
+  EXPORT "${targets_export_name}"
+  NAMESPACE "${namespace}"
+  DESTINATION "${config_install_dir}")
+
+ install(
+   FILES "${project_config}" "${version_config}"
+   DESTINATION "${config_install_dir}")
 
 install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/zmqpp_export.h"
         DESTINATION "include")
+

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+# Boost is statically linked and only for tools that are not installed
+find_package(ZeroMQ)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -1,0 +1,466 @@
+# Copyright (c) 2013-2015, Ruslan Baratov
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is a gate file to Hunter package manager.
+# Include this file using `include` command and add package you need, example:
+#
+#     cmake_minimum_required(VERSION 3.0)
+#
+#     include("cmake/HunterGate.cmake")
+#     HunterGate(
+#         URL "https://github.com/path/to/hunter/archive.tar.gz"
+#         SHA1 "798501e983f14b28b10cda16afa4de69eee1da1d"
+#     )
+#
+#     project(MyProject)
+#
+#     hunter_add_package(Foo)
+#     hunter_add_package(Boo COMPONENTS Bar Baz)
+#
+# Projects:
+#     * https://github.com/hunter-packages/gate/
+#     * https://github.com/ruslo/hunter
+
+cmake_minimum_required(VERSION 3.0) # Minimum for Hunter
+include(CMakeParseArguments) # cmake_parse_arguments
+
+option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
+option(HUNTER_STATUS_PRINT "Print working status" ON)
+option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
+
+set(HUNTER_WIKI "https://github.com/ruslo/hunter/wiki")
+
+function(hunter_gate_status_print)
+  foreach(print_message ${ARGV})
+    if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+      message(STATUS "[hunter] ${print_message}")
+    endif()
+  endforeach()
+endfunction()
+
+function(hunter_gate_status_debug)
+  foreach(print_message ${ARGV})
+    if(HUNTER_STATUS_DEBUG)
+      string(TIMESTAMP timestamp)
+      message(STATUS "[hunter *** DEBUG *** ${timestamp}] ${print_message}")
+    endif()
+  endforeach()
+endfunction()
+
+function(hunter_gate_wiki wiki_page)
+  message("------------------------------ WIKI -------------------------------")
+  message("    ${HUNTER_WIKI}/${wiki_page}")
+  message("-------------------------------------------------------------------")
+  message("")
+  message(FATAL_ERROR "")
+endfunction()
+
+function(hunter_gate_internal_error)
+  message("")
+  foreach(print_message ${ARGV})
+    message("[hunter ** INTERNAL **] ${print_message}")
+  endforeach()
+  message("[hunter ** INTERNAL **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
+  message("")
+  hunter_gate_wiki("error.internal")
+endfunction()
+
+function(hunter_gate_fatal_error)
+  cmake_parse_arguments(hunter "" "WIKI" "" "${ARGV}")
+  if(NOT hunter_WIKI)
+    hunter_gate_internal_error("Expected wiki")
+  endif()
+  message("")
+  foreach(x ${hunter_UNPARSED_ARGUMENTS})
+    message("[hunter ** FATAL ERROR **] ${x}")
+  endforeach()
+  message("[hunter ** FATAL ERROR **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
+  message("")
+  hunter_gate_wiki("${hunter_WIKI}")
+endfunction()
+
+function(hunter_gate_user_error)
+  hunter_gate_fatal_error(${ARGV} WIKI "error.incorrect.input.data")
+endfunction()
+
+function(hunter_gate_self root version sha1 result)
+  string(COMPARE EQUAL "${root}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("root is empty")
+  endif()
+
+  string(COMPARE EQUAL "${version}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("version is empty")
+  endif()
+
+  string(COMPARE EQUAL "${sha1}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("sha1 is empty")
+  endif()
+
+  string(SUBSTRING "${sha1}" 0 7 archive_id)
+
+  if(EXISTS "${root}/cmake/Hunter")
+    set(hunter_self "${root}")
+  else()
+    set(
+        hunter_self
+        "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
+    )
+  endif()
+
+  set("${result}" "${hunter_self}" PARENT_SCOPE)
+endfunction()
+
+# Set HUNTER_GATE_ROOT cmake variable to suitable value.
+function(hunter_gate_detect_root)
+  # Check CMake variable
+  if(HUNTER_ROOT)
+    set(HUNTER_GATE_ROOT "${HUNTER_ROOT}" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT detected by cmake variable")
+    return()
+  endif()
+
+  # Check environment variable
+  string(COMPARE NOTEQUAL "$ENV{HUNTER_ROOT}" "" not_empty)
+  if(not_empty)
+    set(HUNTER_GATE_ROOT "$ENV{HUNTER_ROOT}" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT detected by environment variable")
+    return()
+  endif()
+
+  # Check HOME environment variable
+  string(COMPARE NOTEQUAL "$ENV{HOME}" "" result)
+  if(result)
+    set(HUNTER_GATE_ROOT "$ENV{HOME}/.hunter" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT set using HOME environment variable")
+    return()
+  endif()
+
+  # Check SYSTEMDRIVE and USERPROFILE environment variable (windows only)
+  if(WIN32)
+    string(COMPARE NOTEQUAL "$ENV{SYSTEMDRIVE}" "" result)
+    if(result)
+      set(HUNTER_GATE_ROOT "$ENV{SYSTEMDRIVE}/.hunter" PARENT_SCOPE)
+      hunter_gate_status_debug(
+          "HUNTER_ROOT set using SYSTEMDRIVE environment variable"
+      )
+      return()
+    endif()
+
+    string(COMPARE NOTEQUAL "$ENV{USERPROFILE}" "" result)
+    if(result)
+      set(HUNTER_GATE_ROOT "$ENV{USERPROFILE}/.hunter" PARENT_SCOPE)
+      hunter_gate_status_debug(
+          "HUNTER_ROOT set using USERPROFILE environment variable"
+      )
+      return()
+    endif()
+  endif()
+
+  hunter_gate_fatal_error(
+      "Can't detect HUNTER_ROOT"
+      WIKI "error.detect.hunter.root"
+  )
+endfunction()
+
+macro(hunter_gate_lock dir)
+  if(NOT HUNTER_SKIP_LOCK)
+    if("${CMAKE_VERSION}" VERSION_LESS "3.2")
+      hunter_gate_fatal_error(
+          "Can't lock, upgrade to CMake 3.2 or use HUNTER_SKIP_LOCK"
+          WIKI "error.can.not.lock"
+      )
+    endif()
+    hunter_gate_status_debug("Locking directory: ${dir}")
+    file(LOCK "${dir}" DIRECTORY GUARD FUNCTION)
+    hunter_gate_status_debug("Lock done")
+  endif()
+endmacro()
+
+function(hunter_gate_download dir)
+  if(NOT HUNTER_RUN_INSTALL)
+    hunter_gate_fatal_error(
+        "Hunter not found in '${HUNTER_GATE_ROOT}'"
+        "Set HUNTER_RUN_INSTALL=ON to auto-install it from '${HUNTER_GATE_URL}'"
+        WIKI "error.run.install"
+    )
+  endif()
+  string(COMPARE EQUAL "${dir}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("Empty 'dir' argument")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_GATE_SHA1}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("HUNTER_GATE_SHA1 empty")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_GATE_URL}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("HUNTER_GATE_URL empty")
+  endif()
+
+  set(done_location "${dir}/DONE")
+  set(sha1_location "${dir}/SHA1")
+
+  set(build_dir "${dir}/Build")
+  set(cmakelists "${dir}/CMakeLists.txt")
+
+  hunter_gate_lock("${dir}")
+  if(EXISTS "${done_location}")
+    # while waiting for lock other instance can do all the job
+    hunter_gate_status_debug("File '${done_location}' found, skip install")
+    return()
+  endif()
+
+  file(REMOVE_RECURSE "${build_dir}")
+  file(REMOVE_RECURSE "${cmakelists}")
+
+  file(MAKE_DIRECTORY "${build_dir}") # check directory permissions
+
+  # Disabling languages speeds up a little bit, reduces noise in the output
+  # and avoids path too long windows error
+  file(
+      WRITE
+      "${cmakelists}"
+      "cmake_minimum_required(VERSION 3.0)\n"
+      "project(HunterDownload LANGUAGES NONE)\n"
+      "include(ExternalProject)\n"
+      "ExternalProject_Add(\n"
+      "    Hunter\n"
+      "    URL\n"
+      "    \"${HUNTER_GATE_URL}\"\n"
+      "    URL_HASH\n"
+      "    SHA1=${HUNTER_GATE_SHA1}\n"
+      "    DOWNLOAD_DIR\n"
+      "    \"${dir}\"\n"
+      "    SOURCE_DIR\n"
+      "    \"${dir}/Unpacked\"\n"
+      "    CONFIGURE_COMMAND\n"
+      "    \"\"\n"
+      "    BUILD_COMMAND\n"
+      "    \"\"\n"
+      "    INSTALL_COMMAND\n"
+      "    \"\"\n"
+      ")\n"
+  )
+
+  if(HUNTER_STATUS_DEBUG)
+    set(logging_params "")
+  else()
+    set(logging_params OUTPUT_QUIET)
+  endif()
+
+  hunter_gate_status_debug("Run generate")
+  execute_process(
+      COMMAND "${CMAKE_COMMAND}" "-H${dir}" "-B${build_dir}"
+      WORKING_DIRECTORY "${dir}"
+      RESULT_VARIABLE download_result
+      ${logging_params}
+  )
+
+  if(NOT download_result EQUAL 0)
+    hunter_gate_internal_error("Configure project failed")
+  endif()
+
+  hunter_gate_status_print(
+      "Initializing Hunter workspace (${HUNTER_GATE_SHA1})"
+      "  ${HUNTER_GATE_URL}"
+      "  -> ${dir}"
+  )
+  execute_process(
+      COMMAND "${CMAKE_COMMAND}" --build "${build_dir}"
+      WORKING_DIRECTORY "${dir}"
+      RESULT_VARIABLE download_result
+      ${logging_params}
+  )
+
+  if(NOT download_result EQUAL 0)
+    hunter_gate_internal_error("Build project failed")
+  endif()
+
+  file(REMOVE_RECURSE "${build_dir}")
+  file(REMOVE_RECURSE "${cmakelists}")
+
+  file(WRITE "${sha1_location}" "${HUNTER_GATE_SHA1}")
+  file(WRITE "${done_location}" "DONE")
+
+  hunter_gate_status_debug("Finished")
+endfunction()
+
+# Must be a macro so master file 'cmake/Hunter' can
+# apply all variables easily just by 'include' command
+# (otherwise PARENT_SCOPE magic needed)
+macro(HunterGate)
+  if(HUNTER_GATE_DONE)
+    # variable HUNTER_GATE_DONE set explicitly for external project
+    # (see `hunter_download`)
+    set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)
+  endif()
+
+  # First HunterGate command will init Hunter, others will be ignored
+  get_property(_hunter_gate_done GLOBAL PROPERTY HUNTER_GATE_DONE SET)
+
+  if(NOT HUNTER_ENABLED)
+    # Empty function to avoid error "unknown function"
+    function(hunter_add_package)
+    endfunction()
+  elseif(_hunter_gate_done)
+    hunter_gate_status_debug("Secondary HunterGate (use old settings)")
+    hunter_gate_self(
+        "${HUNTER_CACHED_ROOT}"
+        "${HUNTER_VERSION}"
+        "${HUNTER_SHA1}"
+        _hunter_self
+    )
+    include("${_hunter_self}/cmake/Hunter")
+  else()
+    set(HUNTER_GATE_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
+
+    if(PROJECT_NAME)
+      hunter_gate_fatal_error(
+          "Please set HunterGate *before* 'project' command"
+          WIKI "error.huntergate.before.project"
+      )
+    endif()
+
+    cmake_parse_arguments(
+        HUNTER_GATE "LOCAL" "URL;SHA1;GLOBAL;FILEPATH" "" ${ARGV}
+    )
+    if(NOT HUNTER_GATE_SHA1)
+      hunter_gate_user_error("SHA1 suboption of HunterGate is mandatory")
+    endif()
+    if(NOT HUNTER_GATE_URL)
+      hunter_gate_user_error("URL suboption of HunterGate is mandatory")
+    endif()
+    if(HUNTER_GATE_UNPARSED_ARGUMENTS)
+      hunter_gate_user_error(
+          "HunterGate unparsed arguments: ${HUNTER_GATE_UNPARSED_ARGUMENTS}"
+      )
+    endif()
+    if(HUNTER_GATE_GLOBAL)
+      if(HUNTER_GATE_LOCAL)
+        hunter_gate_user_error("Unexpected LOCAL (already has GLOBAL)")
+      endif()
+      if(HUNTER_GATE_FILEPATH)
+        hunter_gate_user_error("Unexpected FILEPATH (already has GLOBAL)")
+      endif()
+    endif()
+    if(HUNTER_GATE_LOCAL)
+      if(HUNTER_GATE_GLOBAL)
+        hunter_gate_user_error("Unexpected GLOBAL (already has LOCAL)")
+      endif()
+      if(HUNTER_GATE_FILEPATH)
+        hunter_gate_user_error("Unexpected FILEPATH (already has LOCAL)")
+      endif()
+    endif()
+    if(HUNTER_GATE_FILEPATH)
+      if(HUNTER_GATE_GLOBAL)
+        hunter_gate_user_error("Unexpected GLOBAL (already has FILEPATH)")
+      endif()
+      if(HUNTER_GATE_LOCAL)
+        hunter_gate_user_error("Unexpected LOCAL (already has FILEPATH)")
+      endif()
+    endif()
+
+    hunter_gate_detect_root() # set HUNTER_GATE_ROOT
+
+    # Beautify path, fix probable problems with windows path slashes
+    get_filename_component(
+        HUNTER_GATE_ROOT "${HUNTER_GATE_ROOT}" ABSOLUTE
+    )
+    hunter_gate_status_debug("HUNTER_ROOT: ${HUNTER_GATE_ROOT}")
+    string(FIND "${HUNTER_GATE_ROOT}" " " _contain_spaces)
+    if(NOT _contain_spaces EQUAL -1)
+      hunter_gate_fatal_error(
+          "HUNTER_ROOT (${HUNTER_GATE_ROOT}) contains spaces"
+          WIKI "error.spaces.in.hunter.root"
+      )
+    endif()
+
+    string(
+        REGEX
+        MATCH
+        "[0-9]+\\.[0-9]+\\.[0-9]+[-_a-z0-9]*"
+        HUNTER_GATE_VERSION
+        "${HUNTER_GATE_URL}"
+    )
+    string(COMPARE EQUAL "${HUNTER_GATE_VERSION}" "" _is_empty)
+    if(_is_empty)
+      set(HUNTER_GATE_VERSION "unknown")
+    endif()
+
+    hunter_gate_self(
+        "${HUNTER_GATE_ROOT}"
+        "${HUNTER_GATE_VERSION}"
+        "${HUNTER_GATE_SHA1}"
+        hunter_self_
+    )
+
+    set(_master_location "${hunter_self_}/cmake/Hunter")
+    if(EXISTS "${HUNTER_GATE_ROOT}/cmake/Hunter")
+      # Hunter downloaded manually (e.g. by 'git clone')
+      set(_unused "xxxxxxxxxx")
+      set(HUNTER_GATE_SHA1 "${_unused}")
+      set(HUNTER_GATE_VERSION "${_unused}")
+    else()
+      get_filename_component(_archive_id_location "${hunter_self_}/.." ABSOLUTE)
+      set(_done_location "${_archive_id_location}/DONE")
+      set(_sha1_location "${_archive_id_location}/SHA1")
+
+      # Check Hunter already downloaded by HunterGate
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_download("${_archive_id_location}")
+      endif()
+
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_internal_error("hunter_gate_download failed")
+      endif()
+
+      if(NOT EXISTS "${_sha1_location}")
+        hunter_gate_internal_error("${_sha1_location} not found")
+      endif()
+      file(READ "${_sha1_location}" _sha1_value)
+      string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
+      if(NOT _is_equal)
+        hunter_gate_internal_error(
+            "Short SHA1 collision:"
+            "  ${_sha1_value} (from ${_sha1_location})"
+            "  ${HUNTER_GATE_SHA1} (HunterGate)"
+        )
+      endif()
+      if(NOT EXISTS "${_master_location}")
+        hunter_gate_user_error(
+            "Master file not found:"
+            "  ${_master_location}"
+            "try to update Hunter/HunterGate"
+        )
+      endif()
+    endif()
+    include("${_master_location}")
+    set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)
+  endif()
+endmacro()

--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2015, Ruslan Baratov
+# Copyright (c) 2013-2019, Ruslan Baratov
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,7 +25,7 @@
 # This is a gate file to Hunter package manager.
 # Include this file using `include` command and add package you need, example:
 #
-#     cmake_minimum_required(VERSION 3.0)
+#     cmake_minimum_required(VERSION 3.2)
 #
 #     include("cmake/HunterGate.cmake")
 #     HunterGate(
@@ -42,35 +42,46 @@
 #     * https://github.com/hunter-packages/gate/
 #     * https://github.com/ruslo/hunter
 
-cmake_minimum_required(VERSION 3.0) # Minimum for Hunter
+option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
+
+if(HUNTER_ENABLED)
+  if(CMAKE_VERSION VERSION_LESS "3.2")
+    message(
+        FATAL_ERROR
+        "At least CMake version 3.2 required for Hunter dependency management."
+        " Update CMake or set HUNTER_ENABLED to OFF."
+    )
+  endif()
+endif()
+
 include(CMakeParseArguments) # cmake_parse_arguments
 
-option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
 option(HUNTER_STATUS_PRINT "Print working status" ON)
 option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
+option(HUNTER_TLS_VERIFY "Enable/disable TLS certificate checking on downloads" ON)
 
-set(HUNTER_WIKI "https://github.com/ruslo/hunter/wiki")
+set(HUNTER_ERROR_PAGE "https://docs.hunter.sh/en/latest/reference/errors")
 
 function(hunter_gate_status_print)
-  foreach(print_message ${ARGV})
-    if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+  if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+    foreach(print_message ${ARGV})
       message(STATUS "[hunter] ${print_message}")
-    endif()
-  endforeach()
+    endforeach()
+  endif()
 endfunction()
 
 function(hunter_gate_status_debug)
-  foreach(print_message ${ARGV})
-    if(HUNTER_STATUS_DEBUG)
+  if(HUNTER_STATUS_DEBUG)
+    foreach(print_message ${ARGV})
       string(TIMESTAMP timestamp)
       message(STATUS "[hunter *** DEBUG *** ${timestamp}] ${print_message}")
-    endif()
-  endforeach()
+    endforeach()
+  endif()
 endfunction()
 
-function(hunter_gate_wiki wiki_page)
-  message("------------------------------ WIKI -------------------------------")
-  message("    ${HUNTER_WIKI}/${wiki_page}")
+function(hunter_gate_error_page error_page)
+  message("------------------------------ ERROR ------------------------------")
+  message("    ${HUNTER_ERROR_PAGE}/${error_page}.html")
   message("-------------------------------------------------------------------")
   message("")
   message(FATAL_ERROR "")
@@ -83,13 +94,13 @@ function(hunter_gate_internal_error)
   endforeach()
   message("[hunter ** INTERNAL **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
   message("")
-  hunter_gate_wiki("error.internal")
+  hunter_gate_error_page("error.internal")
 endfunction()
 
 function(hunter_gate_fatal_error)
-  cmake_parse_arguments(hunter "" "WIKI" "" "${ARGV}")
-  if(NOT hunter_WIKI)
-    hunter_gate_internal_error("Expected wiki")
+  cmake_parse_arguments(hunter "" "ERROR_PAGE" "" "${ARGV}")
+  if("${hunter_ERROR_PAGE}" STREQUAL "")
+    hunter_gate_internal_error("Expected ERROR_PAGE")
   endif()
   message("")
   foreach(x ${hunter_UNPARSED_ARGUMENTS})
@@ -97,11 +108,11 @@ function(hunter_gate_fatal_error)
   endforeach()
   message("[hunter ** FATAL ERROR **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
   message("")
-  hunter_gate_wiki("${hunter_WIKI}")
+  hunter_gate_error_page("${hunter_ERROR_PAGE}")
 endfunction()
 
 function(hunter_gate_user_error)
-  hunter_gate_fatal_error(${ARGV} WIKI "error.incorrect.input.data")
+  hunter_gate_fatal_error(${ARGV} ERROR_PAGE "error.incorrect.input.data")
 endfunction()
 
 function(hunter_gate_self root version sha1 result)
@@ -122,14 +133,10 @@ function(hunter_gate_self root version sha1 result)
 
   string(SUBSTRING "${sha1}" 0 7 archive_id)
 
-  if(EXISTS "${root}/cmake/Hunter")
-    set(hunter_self "${root}")
-  else()
-    set(
-        hunter_self
-        "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
-    )
-  endif()
+  set(
+      hunter_self
+      "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
+  )
 
   set("${result}" "${hunter_self}" PARENT_SCOPE)
 endfunction()
@@ -137,7 +144,8 @@ endfunction()
 # Set HUNTER_GATE_ROOT cmake variable to suitable value.
 function(hunter_gate_detect_root)
   # Check CMake variable
-  if(HUNTER_ROOT)
+  string(COMPARE NOTEQUAL "${HUNTER_ROOT}" "" not_empty)
+  if(not_empty)
     set(HUNTER_GATE_ROOT "${HUNTER_ROOT}" PARENT_SCOPE)
     hunter_gate_status_debug("HUNTER_ROOT detected by cmake variable")
     return()
@@ -182,30 +190,26 @@ function(hunter_gate_detect_root)
 
   hunter_gate_fatal_error(
       "Can't detect HUNTER_ROOT"
-      WIKI "error.detect.hunter.root"
+      ERROR_PAGE "error.detect.hunter.root"
   )
 endfunction()
 
-macro(hunter_gate_lock dir)
-  if(NOT HUNTER_SKIP_LOCK)
-    if("${CMAKE_VERSION}" VERSION_LESS "3.2")
-      hunter_gate_fatal_error(
-          "Can't lock, upgrade to CMake 3.2 or use HUNTER_SKIP_LOCK"
-          WIKI "error.can.not.lock"
-      )
-    endif()
-    hunter_gate_status_debug("Locking directory: ${dir}")
-    file(LOCK "${dir}" DIRECTORY GUARD FUNCTION)
-    hunter_gate_status_debug("Lock done")
-  endif()
-endmacro()
-
 function(hunter_gate_download dir)
-  if(NOT HUNTER_RUN_INSTALL)
+  string(
+      COMPARE
+      NOTEQUAL
+      "$ENV{HUNTER_DISABLE_AUTOINSTALL}"
+      ""
+      disable_autoinstall
+  )
+  if(disable_autoinstall AND NOT HUNTER_RUN_INSTALL)
     hunter_gate_fatal_error(
-        "Hunter not found in '${HUNTER_GATE_ROOT}'"
+        "Hunter not found in '${dir}'"
         "Set HUNTER_RUN_INSTALL=ON to auto-install it from '${HUNTER_GATE_URL}'"
-        WIKI "error.run.install"
+        "Settings:"
+        "  HUNTER_ROOT: ${HUNTER_GATE_ROOT}"
+        "  HUNTER_SHA1: ${HUNTER_GATE_SHA1}"
+        ERROR_PAGE "error.run.install"
     )
   endif()
   string(COMPARE EQUAL "${dir}" "" is_bad)
@@ -229,7 +233,10 @@ function(hunter_gate_download dir)
   set(build_dir "${dir}/Build")
   set(cmakelists "${dir}/CMakeLists.txt")
 
-  hunter_gate_lock("${dir}")
+  hunter_gate_status_debug("Locking directory: ${dir}")
+  file(LOCK "${dir}" DIRECTORY GUARD FUNCTION)
+  hunter_gate_status_debug("Lock done")
+
   if(EXISTS "${done_location}")
     # while waiting for lock other instance can do all the job
     hunter_gate_status_debug("File '${done_location}' found, skip install")
@@ -246,7 +253,7 @@ function(hunter_gate_download dir)
   file(
       WRITE
       "${cmakelists}"
-      "cmake_minimum_required(VERSION 3.0)\n"
+      "cmake_minimum_required(VERSION 3.2)\n"
       "project(HunterDownload LANGUAGES NONE)\n"
       "include(ExternalProject)\n"
       "ExternalProject_Add(\n"
@@ -257,6 +264,8 @@ function(hunter_gate_download dir)
       "    SHA1=${HUNTER_GATE_SHA1}\n"
       "    DOWNLOAD_DIR\n"
       "    \"${dir}\"\n"
+      "    TLS_VERIFY\n"
+      "    ${HUNTER_TLS_VERIFY}\n"
       "    SOURCE_DIR\n"
       "    \"${dir}/Unpacked\"\n"
       "    CONFIGURE_COMMAND\n"
@@ -275,15 +284,45 @@ function(hunter_gate_download dir)
   endif()
 
   hunter_gate_status_debug("Run generate")
+
+  # Need to add toolchain file too.
+  # Otherwise on Visual Studio + MDD this will fail with error:
+  # "Could not find an appropriate version of the Windows 10 SDK installed on this machine"
+  if(EXISTS "${CMAKE_TOOLCHAIN_FILE}")
+    get_filename_component(absolute_CMAKE_TOOLCHAIN_FILE "${CMAKE_TOOLCHAIN_FILE}" ABSOLUTE)
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=${absolute_CMAKE_TOOLCHAIN_FILE}")
+  else()
+    # 'toolchain_arg' can't be empty
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=")
+  endif()
+
+  string(COMPARE EQUAL "${CMAKE_MAKE_PROGRAM}" "" no_make)
+  if(no_make)
+    set(make_arg "")
+  else()
+    # Test case: remove Ninja from PATH but set it via CMAKE_MAKE_PROGRAM
+    set(make_arg "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}")
+  endif()
+
   execute_process(
-      COMMAND "${CMAKE_COMMAND}" "-H${dir}" "-B${build_dir}"
+      COMMAND
+      "${CMAKE_COMMAND}"
+      "-H${dir}"
+      "-B${build_dir}"
+      "-G${CMAKE_GENERATOR}"
+      "${toolchain_arg}"
+      ${make_arg}
       WORKING_DIRECTORY "${dir}"
       RESULT_VARIABLE download_result
       ${logging_params}
   )
 
   if(NOT download_result EQUAL 0)
-    hunter_gate_internal_error("Configure project failed")
+    hunter_gate_internal_error(
+        "Configure project failed."
+        "To reproduce the error run: ${CMAKE_COMMAND} -H${dir} -B${build_dir} -G${CMAKE_GENERATOR} ${toolchain_arg} ${make_arg}"
+        "In directory ${dir}"
+    )
   endif()
 
   hunter_gate_status_print(
@@ -328,6 +367,17 @@ macro(HunterGate)
     # Empty function to avoid error "unknown function"
     function(hunter_add_package)
     endfunction()
+
+    set(
+        _hunter_gate_disabled_mode_dir
+        "${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/disabled-mode"
+    )
+    if(EXISTS "${_hunter_gate_disabled_mode_dir}")
+      hunter_gate_status_debug(
+          "Adding \"disabled-mode\" modules: ${_hunter_gate_disabled_mode_dir}"
+      )
+      list(APPEND CMAKE_PREFIX_PATH "${_hunter_gate_disabled_mode_dir}")
+    endif()
   elseif(_hunter_gate_done)
     hunter_gate_status_debug("Secondary HunterGate (use old settings)")
     hunter_gate_self(
@@ -338,47 +388,62 @@ macro(HunterGate)
     )
     include("${_hunter_self}/cmake/Hunter")
   else()
-    set(HUNTER_GATE_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
+    set(HUNTER_GATE_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}")
 
-    if(PROJECT_NAME)
+    string(COMPARE NOTEQUAL "${PROJECT_NAME}" "" _have_project_name)
+    if(_have_project_name)
       hunter_gate_fatal_error(
-          "Please set HunterGate *before* 'project' command"
-          WIKI "error.huntergate.before.project"
+          "Please set HunterGate *before* 'project' command. "
+          "Detected project: ${PROJECT_NAME}"
+          ERROR_PAGE "error.huntergate.before.project"
       )
     endif()
 
     cmake_parse_arguments(
         HUNTER_GATE "LOCAL" "URL;SHA1;GLOBAL;FILEPATH" "" ${ARGV}
     )
-    if(NOT HUNTER_GATE_SHA1)
-      hunter_gate_user_error("SHA1 suboption of HunterGate is mandatory")
-    endif()
-    if(NOT HUNTER_GATE_URL)
-      hunter_gate_user_error("URL suboption of HunterGate is mandatory")
-    endif()
-    if(HUNTER_GATE_UNPARSED_ARGUMENTS)
+
+    string(COMPARE EQUAL "${HUNTER_GATE_SHA1}" "" _empty_sha1)
+    string(COMPARE EQUAL "${HUNTER_GATE_URL}" "" _empty_url)
+    string(
+        COMPARE
+        NOTEQUAL
+        "${HUNTER_GATE_UNPARSED_ARGUMENTS}"
+        ""
+        _have_unparsed
+    )
+    string(COMPARE NOTEQUAL "${HUNTER_GATE_GLOBAL}" "" _have_global)
+    string(COMPARE NOTEQUAL "${HUNTER_GATE_FILEPATH}" "" _have_filepath)
+
+    if(_have_unparsed)
       hunter_gate_user_error(
           "HunterGate unparsed arguments: ${HUNTER_GATE_UNPARSED_ARGUMENTS}"
       )
     endif()
-    if(HUNTER_GATE_GLOBAL)
+    if(_empty_sha1)
+      hunter_gate_user_error("SHA1 suboption of HunterGate is mandatory")
+    endif()
+    if(_empty_url)
+      hunter_gate_user_error("URL suboption of HunterGate is mandatory")
+    endif()
+    if(_have_global)
       if(HUNTER_GATE_LOCAL)
         hunter_gate_user_error("Unexpected LOCAL (already has GLOBAL)")
       endif()
-      if(HUNTER_GATE_FILEPATH)
+      if(_have_filepath)
         hunter_gate_user_error("Unexpected FILEPATH (already has GLOBAL)")
       endif()
     endif()
     if(HUNTER_GATE_LOCAL)
-      if(HUNTER_GATE_GLOBAL)
+      if(_have_global)
         hunter_gate_user_error("Unexpected GLOBAL (already has LOCAL)")
       endif()
-      if(HUNTER_GATE_FILEPATH)
+      if(_have_filepath)
         hunter_gate_user_error("Unexpected FILEPATH (already has LOCAL)")
       endif()
     endif()
-    if(HUNTER_GATE_FILEPATH)
-      if(HUNTER_GATE_GLOBAL)
+    if(_have_filepath)
+      if(_have_global)
         hunter_gate_user_error("Unexpected GLOBAL (already has FILEPATH)")
       endif()
       if(HUNTER_GATE_LOCAL)
@@ -393,12 +458,16 @@ macro(HunterGate)
         HUNTER_GATE_ROOT "${HUNTER_GATE_ROOT}" ABSOLUTE
     )
     hunter_gate_status_debug("HUNTER_ROOT: ${HUNTER_GATE_ROOT}")
-    string(FIND "${HUNTER_GATE_ROOT}" " " _contain_spaces)
-    if(NOT _contain_spaces EQUAL -1)
-      hunter_gate_fatal_error(
-          "HUNTER_ROOT (${HUNTER_GATE_ROOT}) contains spaces"
-          WIKI "error.spaces.in.hunter.root"
-      )
+    if(NOT HUNTER_ALLOW_SPACES_IN_PATH)
+      string(FIND "${HUNTER_GATE_ROOT}" " " _contain_spaces)
+      if(NOT _contain_spaces EQUAL -1)
+        hunter_gate_fatal_error(
+            "HUNTER_ROOT (${HUNTER_GATE_ROOT}) contains spaces."
+            "Set HUNTER_ALLOW_SPACES_IN_PATH=ON to skip this error"
+            "(Use at your own risk!)"
+            ERROR_PAGE "error.spaces.in.hunter.root"
+        )
+      endif()
     endif()
 
     string(
@@ -417,48 +486,41 @@ macro(HunterGate)
         "${HUNTER_GATE_ROOT}"
         "${HUNTER_GATE_VERSION}"
         "${HUNTER_GATE_SHA1}"
-        hunter_self_
+        _hunter_self
     )
 
-    set(_master_location "${hunter_self_}/cmake/Hunter")
-    if(EXISTS "${HUNTER_GATE_ROOT}/cmake/Hunter")
-      # Hunter downloaded manually (e.g. by 'git clone')
-      set(_unused "xxxxxxxxxx")
-      set(HUNTER_GATE_SHA1 "${_unused}")
-      set(HUNTER_GATE_VERSION "${_unused}")
-    else()
-      get_filename_component(_archive_id_location "${hunter_self_}/.." ABSOLUTE)
-      set(_done_location "${_archive_id_location}/DONE")
-      set(_sha1_location "${_archive_id_location}/SHA1")
+    set(_master_location "${_hunter_self}/cmake/Hunter")
+    get_filename_component(_archive_id_location "${_hunter_self}/.." ABSOLUTE)
+    set(_done_location "${_archive_id_location}/DONE")
+    set(_sha1_location "${_archive_id_location}/SHA1")
 
-      # Check Hunter already downloaded by HunterGate
-      if(NOT EXISTS "${_done_location}")
-        hunter_gate_download("${_archive_id_location}")
-      endif()
+    # Check Hunter already downloaded by HunterGate
+    if(NOT EXISTS "${_done_location}")
+      hunter_gate_download("${_archive_id_location}")
+    endif()
 
-      if(NOT EXISTS "${_done_location}")
-        hunter_gate_internal_error("hunter_gate_download failed")
-      endif()
+    if(NOT EXISTS "${_done_location}")
+      hunter_gate_internal_error("hunter_gate_download failed")
+    endif()
 
-      if(NOT EXISTS "${_sha1_location}")
-        hunter_gate_internal_error("${_sha1_location} not found")
-      endif()
-      file(READ "${_sha1_location}" _sha1_value)
-      string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
-      if(NOT _is_equal)
-        hunter_gate_internal_error(
-            "Short SHA1 collision:"
-            "  ${_sha1_value} (from ${_sha1_location})"
-            "  ${HUNTER_GATE_SHA1} (HunterGate)"
-        )
-      endif()
-      if(NOT EXISTS "${_master_location}")
-        hunter_gate_user_error(
-            "Master file not found:"
-            "  ${_master_location}"
-            "try to update Hunter/HunterGate"
-        )
-      endif()
+    if(NOT EXISTS "${_sha1_location}")
+      hunter_gate_internal_error("${_sha1_location} not found")
+    endif()
+    file(READ "${_sha1_location}" _sha1_value)
+    string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
+    if(NOT _is_equal)
+      hunter_gate_internal_error(
+          "Short SHA1 collision:"
+          "  ${_sha1_value} (from ${_sha1_location})"
+          "  ${HUNTER_GATE_SHA1} (HunterGate)"
+      )
+    endif()
+    if(NOT EXISTS "${_master_location}")
+      hunter_gate_user_error(
+          "Master file not found:"
+          "  ${_master_location}"
+          "try to update Hunter/HunterGate"
+      )
     endif()
     include("${_master_location}")
     set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)

--- a/src/tests/test_sanity.cpp
+++ b/src/tests/test_sanity.cpp
@@ -13,7 +13,7 @@
  */
 
 // Module definition should only be in one of the tests
-#define BOOST_TEST_DYN_LINK
+//#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE zmqpp
 
 #include <boost/test/unit_test.hpp>


### PR DESCRIPTION
I rebased the repository to [zmqpp](https://github.com/zeromq/zmqpp), and created an hunterized version of last release, 4.2.0, with support for proxy and new zerocopy functions. I needed to update the huntergate, since [local testing](https://docs.hunter.sh/en/latest/creating-new/create/cmake.html#testing-locally) requires an updated version of hunter.
I tested this with linux, adding a few lines about the version to the [hunter.cmake](https://github.com/ruslo/hunter/blob/master/cmake/projects/ZMQPP/hunter.cmake) file of the project:
```cmake
hunter_add_version(
  PACKAGE_NAME
  ZMQPP
  VERSION
  "4.2.0"
  URL
  "https://github.com/hunter-packages/zmqpp/archive/v4.2.0.tar.gz" #create the new release and fix the name
  SHA1
  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx # calculate the sha1sum
  )
```

Hope this helps
